### PR TITLE
Add debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ services:
   logwatcher:
     image: bh.cr/gh_monarci/logwatcher
     environment:
+      DEBUG: 1
       SENTRY_DSN: https://1234@5678.ingest.sentry.io/123456
       LW_Timeout: Schema query timeout
     labels:
@@ -43,9 +44,10 @@ services:
 
 | Environment Variable        | Default | Description                                          |
 | --------------------------- | ------  | -----------------------------------------------------|
-| `SENTRY_DSN`                | ` `     | DSN for sending logs to Sentry service               |
+| `SENTRY_DSN`                | none    | DSN for sending logs to Sentry service               |
 | `SENTRY_TRACES_SAMPLE_RATE` | `1.0`   | Sentry traces sample rate                            |
 | `LW_LEVEL_DEFAULT`          | none    | Default minimum log level that creates an event      |
+| `DEBUG`                     | none    | Output debug logs, `1` to enable                     |
 
 Set any keywords to match with fingerprints with `LW_<fingerprint>` environment variables.
 

--- a/lib/environment.ts
+++ b/lib/environment.ts
@@ -46,4 +46,4 @@ export const sentryConfig: NodeOptions = {
 	),
 };
 
-export const isDevelopment = process.env.NODE_ENV === 'development';
+export const isDebug = process.env.DEBUG === '1';

--- a/lib/eventConverter.ts
+++ b/lib/eventConverter.ts
@@ -1,9 +1,9 @@
-import { Event as SentryEvent } from '@sentry/node/types';
+import type { Event as SentryEvent } from '@sentry/node/types';
 import * as Sentry from '@sentry/node';
 import _ from 'lodash';
-import { JournalEvent } from './journalEvent';
+import type { JournalEvent } from './journalEvent';
 import { sentryTextLogLevels, logLevels } from './sentryLogLevels';
-import { isDevelopment } from './environment';
+import { isDebug } from './environment';
 
 interface LogFormatRegex {
 	name: string;
@@ -195,7 +195,7 @@ function processWithLogFormats(
 	}
 
 	if (matchResult != null) {
-		if (isDevelopment) {
+		if (isDebug) {
 			console.log(
 				`regex ${logFormatRegex.name} matched: ${JSON.stringify(
 					matchResult,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { isDevelopment, triggers, options } from './environment';
+import { isDebug, triggers, options } from './environment';
 import { logEvent, logSentryEvent, sendToSentry } from './logger';
 import { convertToSentryEvent } from './eventConverter';
 import { logLevelsToPriorities } from './sentryLogLevels';
@@ -23,8 +23,8 @@ new Journalctl({
 		return;
 	}
 
-	// Log all received events if in development mode
-	if (isDevelopment) {
+	// Log all received events if in debug mode
+	if (isDebug) {
 		logEvent(event);
 	}
 
@@ -53,7 +53,7 @@ new Journalctl({
 				}
 			}
 
-			if (isDevelopment) {
+			if (isDebug) {
 				logSentryEvent(sentryEvent);
 			}
 			sendToSentry(sentryEvent);


### PR DESCRIPTION
Should only output debug logs if the developer
explicitly wants them as they are noisy. Many
node developers will have NODE_ENV=development
when developing with Livepush, meaning we shouldn't
use that to decide if we should output logwatcher
debug logs as the developer probably doesn't want
them always on during development.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>